### PR TITLE
Implement support for etcd indexes

### DIFF
--- a/lib/etcd/fake_server.rb
+++ b/lib/etcd/fake_server.rb
@@ -274,6 +274,10 @@ class Etcd::FakeServer < Etcd::ServerBase
     }
   end
 
+  def index
+    @index
+  end
+
   def get(key, recursive: nil)
     key, node = read(key)
 
@@ -371,7 +375,11 @@ class Etcd::FakeServer < Etcd::ServerBase
     end
 
     def respond(status, object)
-      return status, { 'Content-Type' => 'application/json' }, object.to_json
+      headers = {
+        'Content-Type' => 'application/json',
+        'X-Etcd-Index' => @server.index,
+      }
+      return status, headers, object.to_json
     end
 
     get '/version' do

--- a/lib/etcd/test_server.rb
+++ b/lib/etcd/test_server.rb
@@ -91,6 +91,11 @@ class Etcd::TestServer < Etcd::ServerBase
     end
   end
 
+  # Return the initial un-modified etcd index after the load!
+  def etcd_index
+    @etcd_index
+  end
+
   # Has the store been modified since reset()?
   #
   # This does not count failed set operations

--- a/spec/models/address_pool_spec.rb
+++ b/spec/models/address_pool_spec.rb
@@ -1,39 +1,31 @@
 describe AddressPool do
-  let :etcd do
-    instance_double(EtcdClient)
-  end
-
   before do
-    EtcdModel.etcd = etcd
     allow_any_instance_of(NodeHelper).to receive(:node).and_return('somehost')
   end
 
-  it 'creates objects in etcd' do
-    expect(etcd).to receive(:set).with('/kontena/ipam/subnets/10.81.0.0', prevExist: false, value: '{"address":"10.81.0.0/16"}')
-    expect(etcd).to receive(:get).with('/kontena/ipam/subnets/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.81.0.0', directory?: false, value: '{"address": "10.81.0.0/16"}'),
-    ]))
-    expect(etcd).to receive(:set).with('/kontena/ipam/pools/kontena', prevExist: false, value: '{"subnet":"10.81.0.0/16","gateway":"10.81.0.1/16"}')
-    expect(etcd).to receive(:set).with('/kontena/ipam/addresses/kontena/', dir: true, prevExist: false)
-    expect(etcd).to receive(:set).with('/kontena/ipam/pool-nodes/kontena/', dir: true, prevExist: false)
-    expect(etcd).to receive(:set).with('/kontena/ipam/addresses/kontena/10.81.0.1', prevExist: false, value: '{"address":"10.81.0.1/16","node":"somehost"}')
-
+  it 'creates objects in etcd', :etcd => true do
     expect(described_class.create('kontena', subnet: IPAddr.new("10.81.0.0/16"))).to eq AddressPool.new('kontena', subnet: IPAddr.new("10.81.0.0/16"), gateway: IPAddr.new('10.81.0.1/16'))
+
+    expect(etcd_server.nodes).to eq(
+      '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+      '/kontena/ipam/pools/kontena' => {"subnet" => "10.81.0.0/16", "gateway" => "10.81.0.1/16"},
+      '/kontena/ipam/addresses/kontena/10.81.0.1' => {"address" => "10.81.0.1/16", "node" => "somehost"},
+    )
   end
 
-  it 'lists objects in etcd' do
-    expect(etcd).to receive(:get).with('/kontena/ipam/pools/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-        instance_double(Etcd::Node, key: '/kontena/ipam/pools/kontena', directory?: false, value: '{"subnet": "10.81.0.0/16"}'),
-    ]))
+  it 'lists objects in etcd', :etcd => true do
+    etcd_server.load!(
+      '/kontena/ipam/pools/kontena' => {"subnet" => "10.81.0.0/16"},
+    )
 
     expect(described_class.list).to eq [
       AddressPool.new("kontena", subnet: IPAddr.new("10.81.0.0/16")),
     ]
   end
 
-  it 'gets objects in etcd' do
-    expect(etcd).to receive(:get).with('/kontena/ipam/pools/kontena').and_return(
-        instance_double(Etcd::Node, key: '/kontena/ipam/pools/kontena', directory?: false, value: '{"subnet": "10.81.0.0/16"}'),
+  it 'gets objects in etcd', :etcd => true do
+    etcd_server.load!(
+      '/kontena/ipam/pools/kontena' => {"subnet" => "10.81.0.0/16"}
     )
 
     expect(described_class.get('kontena')).to eq(
@@ -42,42 +34,37 @@ describe AddressPool do
   end
 
   describe '#create_or_get' do
-    it 'stores new object to etcd' do
-      expect(etcd).to receive(:set).with('/kontena/ipam/subnets/10.81.0.0', prevExist: false, value: '{"address":"10.81.0.0/16"}')
-      expect(etcd).to receive(:get).with('/kontena/ipam/subnets/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-        instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.81.0.0', directory?: false, value: '{"address": "10.81.0.0/16"}'),
-      ]))
-      expect(etcd).to receive(:set).with('/kontena/ipam/pools/kontena', prevExist: false, value: '{"subnet":"10.81.0.0/16","gateway":"10.81.0.1/16"}')
-      expect(etcd).to receive(:set).with('/kontena/ipam/addresses/kontena/', dir: true, prevExist: false)
-      expect(etcd).to receive(:set).with('/kontena/ipam/pool-nodes/kontena/', dir: true, prevExist: false)
-      expect(etcd).to receive(:set).with('/kontena/ipam/addresses/kontena/10.81.0.1', prevExist: false, value: '{"address":"10.81.0.1/16","node":"somehost"}')
-
+    it 'stores new object to etcd', :etcd => true do
       expect(described_class.create_or_get('kontena', subnet: IPAddr.new("10.81.0.0/16"))).to eq AddressPool.new('kontena', subnet: IPAddr.new("10.81.0.0/16"), gateway: IPAddr.new('10.81.0.1/16'))
+
+      expect(etcd_server).to be_modified
+      expect(etcd_server.nodes).to eq(
+        '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+        '/kontena/ipam/pools/kontena' => {"subnet" => "10.81.0.0/16", "gateway" => "10.81.0.1/16"},
+        '/kontena/ipam/addresses/kontena/10.81.0.1' => {"address" => "10.81.0.1/16", "node" => "somehost"},
+      )
     end
 
-    it 'loads existing object from etcd' do
-      expect(etcd).to receive(:set).with('/kontena/ipam/subnets/10.81.0.0', prevExist: false, value: '{"address":"10.81.0.0/16"}')
-      expect(etcd).to receive(:get).with('/kontena/ipam/subnets/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-        instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.0.0', directory?: false, value: '{"address": "10.80.0.0/16"}'),
-        instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.81.0.0', directory?: false, value: '{"address": "10.81.0.0/16"}'),
-      ]))
-
-      expect(etcd).to receive(:set).with('/kontena/ipam/pools/kontena', prevExist: false, value: '{"subnet":"10.81.0.0/16","gateway":"10.81.0.1/16"}').and_raise(Etcd::NodeExist)
-      expect(etcd).to receive(:get).with('/kontena/ipam/pools/kontena').and_return(
-          instance_double(Etcd::Node, key: '/kontena/ipam/pools/kontena', directory?: false, value: '{"subnet": "10.80.0.0/16","gateway":"10.81.0.1/16"}'),
+    it 'loads existing object from etcd', :etcd => true do
+      etcd_server.load!(
+        '/kontena/ipam/subnets/10.80.0.0' => {"address" => "10.80.0.0/16"},
+        '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+        '/kontena/ipam/pools/kontena' => {"subnet" => "10.80.0.0/16", "gateway" => "10.80.0.1/16"}
       )
 
       # yes, it returns with a different subnet
-      expect(described_class.create_or_get('kontena', subnet: IPAddr.new("10.81.0.0/16"))).to eq AddressPool.new('kontena', subnet: IPAddr.new("10.80.0.0/16"), gateway: IPAddr.new('10.81.0.1/16'))
+      expect(described_class.create_or_get('kontena', subnet: IPAddr.new("10.81.0.0/16"))).to eq AddressPool.new('kontena', subnet: IPAddr.new("10.80.0.0/16"), gateway: IPAddr.new('10.80.0.1/16'))
+
+      expect(etcd_server).to_not be_modified
     end
   end
 
-  it 'lists reserved subnets from etcd' do
-    expect(etcd).to receive(:get).with('/kontena/ipam/subnets/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.0.0.0', directory?: false, value: '{"address": "10.80.0.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.0.1.0', directory?: false, value: '{"address": "10.80.1.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.81.0.0', directory?: false, value: '{"address": "10.81.0.0/16"}'),
-    ]))
+  it 'lists reserved subnets from etcd', :etcd => true do
+    etcd_server.load!(
+      '/kontena/ipam/subnets/10.80.0.0' => {"address" => "10.80.0.0/24"},
+      '/kontena/ipam/subnets/10.80.1.0' => {"address" => "10.80.1.0/24"},
+      '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+    )
 
     expect(described_class.reserved_subnets.addrs).to eq [
       IPAddr.new("10.80.0.0/24"),
@@ -86,110 +73,191 @@ describe AddressPool do
     ]
   end
 
-  context 'for an AddressPool' do
+  context 'for an AddressPool', :etcd => true do
+    before do
+      etcd_server.load!(
+        '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+        '/kontena/ipam/pools/kontena' => {"subnet" => "10.81.0.0/16", "iprange" => '10.81.128.0/17', "gateway" => "10.81.0.1/16"},
+        '/kontena/ipam/addresses/kontena/' => nil,
+        '/kontena/ipam/pool-nodes/kontena/' => nil,
+      )
+    end
+
     let :subject do
-      described_class.new('kontena', subnet: IPAddr.new('10.81.0.0/16'), iprange: '10.81.128.0/17', gateway: IPAddr.new('10.81.0.1/16'))
+      AddressPool.get('kontena')
     end
 
     describe '#request!' do
       it 'requests a PoolNode' do
-        expect(PoolNode).to receive(:create_or_get).with('kontena', 'somehost').and_return(PoolNode.new('kontena', 'somehost'))
-
         subject.request!
+
+        expect(etcd_server).to be_modified
+        expect(etcd_server.logs).to eq [
+          [:create, '/kontena/ipam/pool-nodes/kontena/somehost'],
+        ]
       end
     end
 
     describe '#orphaned?' do
       it 'is orphaned if there are no PoolNodes' do
-        expect(PoolNode).to receive(:list).with('kontena').and_return([])
-
         expect(subject).to be_orphaned
       end
 
       it 'is not orphaned if there are PoolNodes' do
-        expect(PoolNode).to receive(:list).with('kontena').and_return([
-          PoolNode.new('kontena', "testhost")
-        ])
+        etcd_server.load!(
+          '/kontena/ipam/pool-nodes/kontena/otherhost' => {},
+        )
 
         expect(subject).to_not be_orphaned
+
+        expect(etcd_server).to_not be_modified
       end
     end
 
     describe '#release!' do
       it 'releases the PoolNode' do
-        expect(PoolNode).to receive(:delete).with('kontena', 'somehost')
+        etcd_server.load!(
+          '/kontena/ipam/pool-nodes/kontena/somehost' => {},
+        )
 
         subject.release!
+
+        expect(etcd_server).to be_modified
+        expect(etcd_server.logs).to eq [
+          [:delete, '/kontena/ipam/pool-nodes/kontena/somehost'],
+        ]
       end
     end
 
     it 'creates an address' do
-      expect(subject).to receive(:node).and_return('somehost')
-      expect(etcd).to receive(:set).with('/kontena/ipam/addresses/kontena/10.81.0.1', prevExist: false, value: '{"address":"10.81.0.1/16","node":"somehost"}')
-
       addr = subject.create_address(IPAddr.new('10.81.0.1'))
 
       expect(addr).to eq Address.new('kontena', '10.81.0.1', node: 'somehost', address: IPAddr.new('10.81.0.1/16'))
       expect(addr.address.to_cidr).to eq '10.81.0.1/16'
+
+      expect(etcd_server).to be_modified
+      expect(etcd_server.logs).to eq [
+        [:create, '/kontena/ipam/addresses/kontena/10.81.0.1'],
+      ]
+      expect(etcd_server.nodes).to eq(
+        '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+        '/kontena/ipam/pools/kontena' => {"subnet" => "10.81.0.0/16", "iprange" => '10.81.128.0/17', "gateway" => "10.81.0.1/16"},
+        '/kontena/ipam/addresses/kontena/10.81.0.1' => {"address" => "10.81.0.1/16", "node" => "somehost"},
+      )
     end
 
     it 'gets an address from etcd' do
-      expect(etcd).to receive(:get).with('/kontena/ipam/addresses/kontena/10.81.0.1').and_return(
-        instance_double(Etcd::Node, key: '/kontena/ipam/addresses/kontena/10.81.0.1', directory?: false, value: '{"address": "10.81.0.1/16"}'),
+      etcd_server.load!(
+        '/kontena/ipam/addresses/kontena/10.81.0.1' => {"address" => "10.81.0.1/16", "node" => "somehost"},
       )
 
       addr = subject.get_address(IPAddr.new('10.81.0.1'))
 
-      expect(addr).to eq Address.new('kontena', '10.81.0.1', address: IPAddr.new('10.81.0.1/16'))
+      expect(addr).to eq Address.new('kontena', '10.81.0.1', address: IPAddr.new('10.81.0.1/16'), node: "somehost")
       expect(addr.address).to eq IPAddr.new('10.81.0.1/16')
       expect(addr.address.to_cidr).to eq '10.81.0.1/16'
+
+      expect(etcd_server).to_not be_modified
+
     end
 
     it 'gets an missing address from etcd' do
-      expect(etcd).to receive(:get).with('/kontena/ipam/addresses/kontena/10.81.0.1').and_raise(Etcd::KeyNotFound)
-
       addr = subject.get_address(IPAddr.new('10.81.0.1'))
 
       expect(addr).to be_nil
+
+      expect(etcd_server).to_not be_modified
     end
 
     it 'lists addresses from etcd' do
-      expect(etcd).to receive(:get).with('/kontena/ipam/addresses/kontena/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-        instance_double(Etcd::Node, key: '/kontena/ipam/addresses/kontena/10.81.0.1', directory?: false, value: '{"address": "10.81.0.1/16"}'),
-      ]))
+      etcd_server.load!(
+        '/kontena/ipam/addresses/kontena/10.81.0.1' => {"address" => "10.81.0.1/16", "node" => "somehost"},
+      )
 
       addrs = subject.list_addresses
 
       expect(addrs).to eq [
-        Address.new('kontena', '10.81.0.1', address: IPAddr.new('10.81.0.1/16')),
+        Address.new('kontena', '10.81.0.1', address: IPAddr.new('10.81.0.1/16'), node: "somehost"),
       ]
       expect(addrs.first.address.to_cidr).to eq '10.81.0.1/16'
+
+      expect(etcd_server).to_not be_modified
     end
 
     it 'lists reserved addresses from etcd' do
-      expect(etcd).to receive(:get).with('/kontena/ipam/addresses/kontena/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-        instance_double(Etcd::Node, key: '/kontena/ipam/addresses/kontena/10.81.0.1', directory?: false, value: '{"address": "10.81.0.1/16"}'),
-      ]))
+      etcd_server.load!(
+        '/kontena/ipam/addresses/kontena/10.81.0.1' => {"address" => "10.81.0.1/16", "node" => "somehost"},
+      )
 
       ipset = subject.reserved_addresses
       expect(ipset.addrs).to eq [
         IPAddr.new('10.81.0.1')
       ]
+
+      expect(etcd_server).to_not be_modified
     end
 
-    it 'deletes objects in etcd' do
-      expect(etcd).to receive(:delete).with('/kontena/ipam/pool-nodes/kontena/', dir: true)
-      expect(etcd).to receive(:delete).with('/kontena/ipam/pools/kontena')
-      expect(etcd).to receive(:delete).with('/kontena/ipam/addresses/kontena/', recursive: true)
-      expect(etcd).to receive(:delete).with('/kontena/ipam/subnets/10.81.0.0', recursive: false)
+    describe '#delete' do
+      it 'raises conflict if pool is in use' do
+        etcd_server.load!(
+          '/kontena/ipam/pool-nodes/kontena/somehost' => {},
+        )
 
-      subject.delete!
+        expect{subject.delete!}.to raise_error(PoolNode::Conflict)
+
+        expect(etcd_server).to_not be_modified
+      end
+
+      it 'deletes orpaned pool in etcd' do
+        subject.delete!
+
+        expect(etcd_server).to be_modified
+        expect(etcd_server.logs).to eq [
+          [:delete, '/kontena/ipam/pool-nodes/kontena/'],
+          [:delete, '/kontena/ipam/pools/kontena'],
+          [:delete, '/kontena/ipam/addresses/kontena/'],
+          [:delete, '/kontena/ipam/subnets/10.81.0.0'],
+        ]
+      end
+    end
+
+    describe '#cleanup' do
+      it 'returns false if still in use' do
+        etcd_server.load!(
+          '/kontena/ipam/pool-nodes/kontena/somehost' => {},
+        )
+
+        expect(subject.cleanup).to be_falsey
+
+        expect(etcd_server).to_not be_modified
+      end
+
+      it 'returns true if deleted' do
+        expect(subject.cleanup).to be_truthy
+
+        expect(etcd_server).to be_modified
+        expect(etcd_server.logs).to eq [
+          [:delete, '/kontena/ipam/pool-nodes/kontena/'],
+          [:delete, '/kontena/ipam/pools/kontena'],
+          [:delete, '/kontena/ipam/addresses/kontena/'],
+          [:delete, '/kontena/ipam/subnets/10.81.0.0'],
+        ]
+      end
     end
   end
 
-  context 'for an AddressPool without an iprange' do
+  context 'for an AddressPool without an iprange', :etcd => true do
+    before do
+      etcd_server.load!(
+        '/kontena/ipam/subnets/10.80.0.0' => {"address" => "10.80.0.0/24"},
+        '/kontena/ipam/pools/test0' => {"subnet" => "10.80.0.0/24", "gateway" => "10.80.0.1/24"},
+        '/kontena/ipam/addresses/test0/10.80.0.1' => {'address' => "10.80.0.1/24"},
+        '/kontena/ipam/pool-nodes/test0/' => nil,
+      )
+    end
+
     let :subject do
-      described_class.new('test', subnet: IPAddr.new('10.80.0.0/24'), gateway: IPAddr.new('10.80.0.1/24'))
+      AddressPool.get('test0')
     end
 
     describe '#allocation_range' do
@@ -201,34 +269,41 @@ describe AddressPool do
 
     describe '#available_addresses' do
       it 'returns the reduced subnet pool' do
-        expect(etcd).to receive(:get).with('/kontena/ipam/addresses/test/').and_return(instance_double(Etcd::Response, directory?: true, children: []))
-
-        addresses = subject.available_addresses.to_a
-
-        expect(addresses.first).to eq IPAddr.new('10.80.0.1/24')
-        expect(addresses).to eq (IPAddr.new('10.80.0.1/24')..IPAddr.new('10.80.0.254/24')).to_a
-        expect(addresses.last).to eq IPAddr.new('10.80.0.254/24')
-        expect(addresses.size).to eq(254)
-
-      end
-
-      it 'excludes reserved addresses from the reduced subnet pool' do
-        expect(etcd).to receive(:get).with('/kontena/ipam/addresses/test/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-          instance_double(Etcd::Node, key: '/kontena/ipam/addresses/kontena/10.80.0.1', directory?: false, value: '{"address": "10.80.0.1/24"}'),
-        ]))
-
         addresses = subject.available_addresses.to_a
 
         expect(addresses.first).to eq IPAddr.new('10.80.0.2/24')
         expect(addresses).to eq (IPAddr.new('10.80.0.2/24')..IPAddr.new('10.80.0.254/24')).to_a
+        expect(addresses.last).to eq IPAddr.new('10.80.0.254/24')
         expect(addresses.size).to eq(253)
+
+      end
+
+      it 'excludes reserved addresses from the reduced subnet pool' do
+        etcd_server.load!(
+          '/kontena/ipam/addresses/test0/10.80.0.2' => {"address" => "10.80.0.2/24", 'node' => "somehost"}
+        )
+
+        addresses = subject.available_addresses.to_a
+
+        expect(addresses.first).to eq IPAddr.new('10.80.0.3/24')
+        expect(addresses).to eq (IPAddr.new('10.80.0.3/24')..IPAddr.new('10.80.0.254/24')).to_a
+        expect(addresses.size).to eq(252)
       end
     end
   end
 
-  context 'for an AddressPool with an iprange' do
+  context 'for an AddressPool with an iprange', :etcd => true do
+    before do
+      etcd_server.load!(
+        '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+        '/kontena/ipam/pools/kontena' => {"subnet" => "10.81.0.0/16", "iprange" => '10.81.1.0/29', "gateway" => "10.81.0.1/16"},
+        '/kontena/ipam/addresses/kontena/' => nil,
+        '/kontena/ipam/pool-nodes/kontena/' => nil,
+      )
+    end
+
     let :subject do
-      AddressPool.new('test', subnet: IPAddr.new('10.81.0.0/16'), iprange: IPAddr.new('10.81.1.0/29'))
+      AddressPool.get('kontena')
     end
 
     let :addresses do
@@ -271,13 +346,10 @@ describe AddressPool do
 
     describe '#available_addresses' do
       it 'returns enumerator' do
-        expect(etcd).to receive(:get).with('/kontena/ipam/addresses/test/').and_return(instance_double(Etcd::Response, directory?: true, children: []))
         expect(subject.available_addresses).to be_instance_of(Enumerator)
       end
 
       it 'returns the full iprange pool' do
-        expect(etcd).to receive(:get).with('/kontena/ipam/addresses/test/').and_return(instance_double(Etcd::Response, directory?: true, children: []))
-
         addresses = subject.available_addresses.to_a
 
         expect(addresses.first).to eq IPAddr.new('10.81.1.0/16')
@@ -287,19 +359,29 @@ describe AddressPool do
       end
 
       it 'excludes reserved addresses from the full iprange pool' do
-        expect(etcd).to receive(:get).with('/kontena/ipam/addresses/test/').and_return(instance_double(Etcd::Response, directory?: true, children: reserved.map{|a|
-          instance_double(Etcd::Node, key: "/kontena/ipam/addresses/test/#{a.to_s}", directory?: false, value: {'address' => a}.to_json)
-        }))
+        reserved.each do |addr|
+          etcd_server.load! "/kontena/ipam/addresses/kontena/#{addr.to_s}" => { 'address' => addr.to_cidr, 'node' => 'somenode' }
+        end
 
         expect(subject.available_addresses.to_a).to eq available
       end
     end
   end
 
-  context 'for an AddressPool with an iprange at the edge of the subnet' do
-    let :subject do
-      AddressPool.new('test', subnet: IPAddr.new('10.81.0.0/16'), iprange: IPAddr.new('10.81.0.0/24'))
+  context 'for an AddressPool with an iprange at the edge of the subnet', :etcd => true do
+    before do
+      etcd_server.load!(
+        '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+        '/kontena/ipam/pools/kontena' => {"subnet" => "10.81.0.0/16", "iprange" => '10.81.0.0/24', "gateway" => "10.81.0.1/16"},
+        '/kontena/ipam/addresses/kontena/' => nil,
+        '/kontena/ipam/pool-nodes/kontena/' => nil,
+      )
     end
+
+    let :subject do
+      AddressPool.get('kontena')
+    end
+
 
     describe '#allocation_range' do
       it 'allocates from the full range' do
@@ -310,8 +392,6 @@ describe AddressPool do
 
     describe '#available_addresses' do
       it 'returns the reduced iprange' do
-        expect(etcd).to receive(:get).with('/kontena/ipam/addresses/test/').and_return(instance_double(Etcd::Response, directory?: true, children: []))
-
         addresses = subject.available_addresses.to_a
 
         expect(addresses.first).to eq IPAddr.new('10.81.0.1/16')

--- a/spec/models/subnet_spec.rb
+++ b/spec/models/subnet_spec.rb
@@ -1,67 +1,73 @@
 describe Subnet do
-  let :etcd do
-    instance_double(EtcdClient)
+  context "with etcd having three subnets", :etcd => true do
+    before do
+      etcd_server.load!(
+        '/kontena/ipam/subnets/10.80.1.0' => {"address": "10.80.1.0/24"},
+        '/kontena/ipam/subnets/10.80.2.0' => {"address": "10.80.2.0/24"},
+        '/kontena/ipam/subnets/10.81.0.0' => {"address": "10.81.0.0/16"},
+      )
+    end
+
+    it 'lists all subnets in etcd', :etcd => true do
+      expect(Subnet.all.addrs).to eq [
+        IPAddr.new('10.80.1.0/24'),
+        IPAddr.new('10.80.2.0/24'),
+        IPAddr.new('10.81.0.0/16'),
+      ]
+
+      expect(etcd_server).to_not be_modified
+    end
+
+    it 'reserves a subnet in etcd', :etcd => true do
+      expect(Subnet.reserve(IPAddr.new('10.82.0.0/16'))).to eq Subnet.new('10.82.0.0', address: IPAddr.new('10.82.0.0/16'))
+
+      expect(etcd_server).to be_modified
+      expect(etcd_server.logs).to eq [
+        [:create, '/kontena/ipam/subnets/10.82.0.0'],
+      ]
+      expect(etcd_server.nodes).to eq(
+        '/kontena/ipam/subnets/10.80.1.0' => {"address" => "10.80.1.0/24"},
+        '/kontena/ipam/subnets/10.80.2.0' => {"address" => "10.80.2.0/24"},
+        '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+        '/kontena/ipam/subnets/10.82.0.0' => {"address" => "10.82.0.0/16"},
+      )
+    end
+
+    it 'raises on conflict', :etcd => true do
+      expect{Subnet.reserve(IPAddr.new('10.81.0.0/16'))}.to raise_error(Subnet::Conflict)
+
+      expect(etcd_server).to_not be_modified
+    end
+
+    it 'raises on underlap conflict', :etcd => true do
+      expect{Subnet.reserve(IPAddr.new('10.80.0.0/16'))}.to raise_error(Subnet::Conflict)
+
+      expect(etcd_server).to be_modified
+      expect(etcd_server.logs).to eq [
+        [:create, '/kontena/ipam/subnets/10.80.0.0'],
+        [:delete, '/kontena/ipam/subnets/10.80.0.0'],
+      ]
+      expect(etcd_server.nodes).to eq(
+        '/kontena/ipam/subnets/10.80.1.0' => {"address" => "10.80.1.0/24"},
+        '/kontena/ipam/subnets/10.80.2.0' => {"address" => "10.80.2.0/24"},
+        '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+      )
+    end
+
+    it 'raises on overlap conflict' do
+      expect{Subnet.reserve(IPAddr.new('10.81.1.0/24'))}.to raise_error(Subnet::Conflict)
+
+      expect(etcd_server).to be_modified
+      expect(etcd_server.logs).to eq [
+        [:create, '/kontena/ipam/subnets/10.81.1.0'],
+        [:delete, '/kontena/ipam/subnets/10.81.1.0'],
+      ]
+      expect(etcd_server.nodes).to eq(
+        '/kontena/ipam/subnets/10.80.1.0' => {"address" => "10.80.1.0/24"},
+        '/kontena/ipam/subnets/10.80.2.0' => {"address" => "10.80.2.0/24"},
+        '/kontena/ipam/subnets/10.81.0.0' => {"address" => "10.81.0.0/16"},
+      )
+    end
   end
 
-  before do
-    EtcdModel.etcd = etcd
-  end
-
-  it 'lists all subnets in etcd' do
-    expect(etcd).to receive(:get).with('/kontena/ipam/subnets/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.1.0', directory?: false, value: '{"address": "10.80.1.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.2.0', directory?: false, value: '{"address": "10.80.2.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.81.0.0', directory?: false, value: '{"address": "10.81.0.0/16"}'),
-    ]))
-
-    expect(Subnet.all.addrs).to eq [
-      IPAddr.new('10.80.1.0/24'),
-      IPAddr.new('10.80.2.0/24'),
-      IPAddr.new('10.81.0.0/16'),
-    ]
-  end
-
-  it 'reserves a subnet in etcd' do
-    expect(etcd).to receive(:set).with('/kontena/ipam/subnets/10.82.0.0', prevExist: false, value: '{"address":"10.82.0.0/16"}')
-    expect(etcd).to receive(:get).with('/kontena/ipam/subnets/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.1.0', directory?: false, value: '{"address": "10.80.1.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.2.0', directory?: false, value: '{"address": "10.80.2.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.81.0.0', directory?: false, value: '{"address": "10.81.0.0/16"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.82.0.0', directory?: false, value: '{"address": "10.82.0.0/16"}'),
-    ]))
-
-    expect(Subnet.reserve(IPAddr.new('10.82.0.0/16'))).to eq Subnet.new('10.82.0.0', address: IPAddr.new('10.82.0.0/16'))
-  end
-
-  it 'raises on conflict' do
-    expect(etcd).to receive(:set).with('/kontena/ipam/subnets/10.81.0.0', prevExist: false, value: '{"address":"10.81.0.0/16"}').and_raise(Etcd::NodeExist)
-
-    expect{Subnet.reserve(IPAddr.new('10.81.0.0/16'))}.to raise_error(Subnet::Conflict)
-  end
-
-  it 'raises on underlap conflict' do
-    expect(etcd).to receive(:set).with('/kontena/ipam/subnets/10.80.0.0', prevExist: false, value: '{"address":"10.80.0.0/16"}')
-    expect(etcd).to receive(:get).with('/kontena/ipam/subnets/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.0.0', directory?: false, value: '{"address": "10.80.0.0/16"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.1.0', directory?: false, value: '{"address": "10.80.1.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.2.0', directory?: false, value: '{"address": "10.80.2.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.81.0.0', directory?: false, value: '{"address": "10.81.0.0/16"}'),
-    ]))
-    expect(etcd).to receive(:delete).with('/kontena/ipam/subnets/10.80.0.0')
-
-    expect{Subnet.reserve(IPAddr.new('10.80.0.0/16'))}.to raise_error(Subnet::Conflict)
-  end
-
-  it 'raises on overlap conflict' do
-    expect(etcd).to receive(:set).with('/kontena/ipam/subnets/10.81.1.0', prevExist: false, value: '{"address":"10.81.1.0/24"}')
-    expect(etcd).to receive(:get).with('/kontena/ipam/subnets/').and_return(instance_double(Etcd::Response, directory?: true, children: [
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.1.0', directory?: false, value: '{"address": "10.80.1.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.80.2.0', directory?: false, value: '{"address": "10.80.2.0/24"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.81.0.0', directory?: false, value: '{"address": "10.81.0.0/16"}'),
-      instance_double(Etcd::Node, key: '/kontena/ipam/subnets/10.81.1.0', directory?: false, value: '{"address": "10.81.1.0/24"}'),
-    ]))
-    expect(etcd).to receive(:delete).with('/kontena/ipam/subnets/10.81.1.0')
-
-    expect{Subnet.reserve(IPAddr.new('10.81.1.0/24'))}.to raise_error(Subnet::Conflict)
-  end
 end

--- a/spec/mutations/address_pools/release_spec.rb
+++ b/spec/mutations/address_pools/release_spec.rb
@@ -43,8 +43,8 @@ describe AddressPools::Release do
       it 'releases the PoolNode and skips the pool delete if still in use' do
         subject = described_class.new(pool_id: 'kontena')
 
-        expect(PoolNode).to receive(:delete).with('kontena', "somehost")
-        expect(PoolNode).to receive(:rmdir).with('kontena').and_raise(PoolNode::Conflict)
+        expect(pool).to receive(:release!)
+        expect(pool).to receive(:delete!).and_raise(PoolNode::Conflict)
 
         outcome = subject.run
 
@@ -54,11 +54,8 @@ describe AddressPools::Release do
       it 'releases the PoolNode and deletes the pool if not in use anymore' do
         subject = described_class.new(pool_id: 'kontena')
 
-        expect(PoolNode).to receive(:delete).with('kontena', "somehost")
-        expect(PoolNode).to receive(:rmdir).with('kontena')
-        expect(etcd).to receive(:delete).with('/kontena/ipam/pools/kontena')
-        expect(Address).to receive(:delete).with('kontena')
-        expect(Subnet).to receive(:delete).with(IPAddr.new('10.80.0.0/16'))
+        expect(pool).to receive(:release!)
+        expect(pool).to receive(:delete!)
 
         outcome = subject.run
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,7 @@ RSpec.configure do |config|
 
   # kill etcd queries for non-etcd examples
   config.before(:each) do
-    EtcdModel.etcd = double()
+    EtcdModel.etcd = instance_double(EtcdClient)
   end
 
   config.before(:each, :etcd => true) do


### PR DESCRIPTION
* Implement `Etcd::FakeServer` support for etcd indexes

* Add `EtcdModel` `@etcd_node`

    Gets initialized from each `get!, `create!`, `update!` or `delete!` operation

* Provide `EtcdModel#etcd_index`

    Returns the last-modified etcd-index for the node

* Provide `EtcdModel#etcd_modified?`after_index: ...`

    Tests if the model node has been created or modified after the given index

* Rewrite all IPAM specs to use the `etcd_server` interface instead of mocking out the `etcd` client

    Mocking out all the etcd node details gets cumbersome. Only some odd spec cases mock out the etcd client anymore:

    `$ rgrep -n 'expect(etcd)' spec/ | grep -v and_call_original`
    ```
    spec/etcd/keys_spec.rb:16:    expect(etcd).to receive(:get).with('/kontena/ipam/pools/').and_return(instance_double(Etcd::Response,
    spec/etcd/model_spec.rb:267:        expect(etcd).to receive(:get).with('/kontena/ipam/test/test1').and_raise(Etcd::KeyNotFound)
    ```

## TODO

* Fix `AddressPool.create_or_get` behavior with `Subnet::Conflict`

    Having `AddressPool.create!` first run `Subnet.create!` before `super` means that the `AddressPools::Request` logic for concurrent `AddressPools::Request` operations for the same static subnet is subtly broken ATM

    The new test case also better demonstrates the need for #43 to cleanup orphaned subnets after conflicts.